### PR TITLE
Fix #1: Use Grammarly to spell check the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dynamic SSL pinning for iOS
 
-`WultraSSLPinning` is library implementing dynamic SSL pinning, written in Swift.  
+`WultraSSLPinning` is a library implementing dynamic SSL pinning, written in Swift.  
 
 - [Introduction](#introduction)
 - [Installation](#installation)
@@ -20,12 +20,12 @@
 
 ## Introduction
 
-The SSL pinning (or [public key, or certificate pinning](https://en.wikipedia.org/wiki/Transport_Layer_Security#Certificate_pinning)) is a technique mitigating [Man-in-the-middle attacks](https://en.wikipedia.org/wiki/Man-in-the-middle_attack) against the secure HTTP communication. The typical iOS solution is to bundle the hash of the certificate, or the exact data of the certificate to the application and validate the incoming challenge in the `URLSessionDelegate`. This in general works well, but it has unfortunately one major drawback in the certificate's expiration date. The certificate expiration forces you to update your application regularly, before the certificate expires, but still, some percentage of the users don't update their apps automatically. So, the users on the older version, will not be able to contact the application servers.
+The SSL pinning (or [public key, or certificate pinning](https://en.wikipedia.org/wiki/Transport_Layer_Security#Certificate_pinning)) is a technique mitigating [Man-in-the-middle attacks](https://en.wikipedia.org/wiki/Man-in-the-middle_attack) against the secure HTTP communication. The typical iOS solution is to bundle the hash of the certificate, or the exact data of the certificate to the application and validate the incoming challenge in the `URLSessionDelegate`. This in general works well, but it has, unfortunately, one major drawback of the certificate's expiration date. The certificate expiration forces you to update your application regularly before the certificate expires, but still, some percentage of the users don't update their apps automatically. So, the users on the older version, will not be able to contact the application servers.
 
-The solution for this problem is the dynamic SSL pinning, where the list of certificate fingerprints are securely downloaded from the remote server. The `WultraSSLPinning` library does exactly that:
+The solution to this problem is the dynamic SSL pinning, where the list of certificate fingerprints are securely downloaded from the remote server. The `WultraSSLPinning` library does precisely thist:
 
 - Manages the dynamic list of certificates, downloaded from the remote server
-- All entries in the list are signed with your private key, and validated in the library with using the public key (we're using ECDSA-SHA-256 algorithm)
+- All entries in the list are signed with your private key and validated in the library with using the public key (we're using ECDSA-SHA-256 algorithm)
 - Provides easy to use fingerprint validation on the TLS handshake.
 
 Before you start using the library, you should also check our other related projects:
@@ -59,20 +59,20 @@ target '<Your Target App>' do
 end
 ```
 
-The current version of library depends on [PowerAuth2](https://github.com/wultra/powerauth-mobile-sdk) framework, version `0.19.1` and greater.
+The current version of the library depends on [PowerAuth2](https://github.com/wultra/powerauth-mobile-sdk) framework, version `0.19.1` and greater.
 
 ### Carthage
 
 *Note that Carthage integration is experimental. We don't provide support for this type of installation.*
 
-[Carthage](https://github.com/Carthage/Carthage) is a decentralized dependency manager that builds your dependencies and provides you with binary frameworks. You can install Carthage with [Homebrew](https://brew.sh) using the following command:
+[Carthage](https://github.com/Carthage/Carthage) is a decentralized dependency manager that builds your dependencies and provides you with binary frameworks. You can install Carthage with [Homebrew](https://brew.sh/) using the following command:
 
 ```bash
 $ brew update
 $ brew install carthage
 ```
 
-To integrate library into your Xcode project using Carthage, specify it in your `Cartfile`:
+To integrate the library into your Xcode project using Carthage, specify it in your `Cartfile`:
 ```
 github "wultra/WultraSSLPinning"
 ```
@@ -83,7 +83,7 @@ Run `carthage update` to build the framework and drag the built `WultraSSLPinnin
 
 ## Usage
 
-The library provides following core types:
+The library provides the following core types:
 
 - `CertStore` - the main class which provides all tasks for dynamic pinning  
 - `CertStoreConfiguration` - the configuration structure for `CertStore` class
@@ -105,22 +105,22 @@ let certStore = CertStore.powerAuthCertStore(configuration: configuration)
 ```
 *We'll use `certStore` variable in the rest of the documentation as a reference to already configured `CertStore` instance.*
 
-The configuration has following properties:
+The configuration has the following properties:
 
-- `serviceUrl` - parameter defining URL with remote list of certificates. It is recommended that `serviceUrl` points to a different domain than you're going to protect with pinning. See [FAQ](#faq) section for more details.
-- `publicKey` - contains public key counterpart to private key, used for data signing. The BASE64 formatted string is expected.
-- `expectedCommonNames` - optional array of strings, defining which domains you expect in certificate validation.
+- `serviceUrl` - parameter defining URL with a remote list of certificates. It is recommended that `serviceUrl` points to a different domain than you're going to protect with pinning. See the [FAQ](#faq) section for more details.
+- `publicKey` - contains the public key counterpart to the private key, used for data signing. The Base64 formatted string is expected.
+- `expectedCommonNames` - an optional array of strings, defining which domains you expect in certificate validation.
 - `identifier` - optional string identifier for scenarios, where multiple `CertStore` instances are used in the application
-- `fallbackCertificateData` - optional hardcoded data for fallback fingerprint. See the next chapter of this document for details.
-- `periodicUpdateInterval` - defines how often will `CertStore` update the fingerprints silently at the background. Default value is 1 week.
+- `fallbackCertificateData` - optional hardcoded data for a fallback fingerprint. See the next chapter of this document for details.
+- `periodicUpdateInterval` - defines how often will `CertStore` update the fingerprints silently at the background. The default value is 1 week.
 - `expirationUpdateTreshold` - defines time window before the next certificate will expire. In this time window `CertStore` will try to update the list of fingerprints more often than usual. Default value is 2 weeks before the next expiration.
 
 
 ### Predefined fingerprint
 
-The `CertStoreConfiguration` may contain an optional data with predefined certificate fingerprint. This technique can speedup the first application's startup when the database of fingerprints is empty. You still need to update your application, once the fallback fingerprint expires. 
+The `CertStoreConfiguration` may contain an optional data with predefined certificate fingerprint. This technique can speed up the first application's startup when the database of fingerprints is empty. You still need to update your application, once the fallback fingerprint expires. 
 
-To configure the property, you need to provide JSON data with fallback fingerprint. The JSON should contains the same data as are usually received from the server, except that "signature" property is not validated (but must be provided in JSON). For example:
+To configure the property, you need to provide JSON data with a fallback fingerprint. The JSON should contain the same data as are usually received from the server, except that "signature" property is not validated (but must be provided in JSON). For example:
 
 ```swift
 let fallbackData = """
@@ -171,7 +171,7 @@ certStore.update { (result, error) in
        // to validate the fingerprints.
    } else {
        // Other error. See `CertStore.UpdateResult` for details.
-       // The "error" variable is set in case of network error.
+       // The "error" variable is set in case of a network error.
    }
 }
 ```
@@ -181,7 +181,7 @@ You have to typically call the update on your application's startup, before you 
 - **Blocking mode**, when your application has to wait for downloading the list of certificates. This typically happens when all certificate fingerprints did expire, or on the application's first start (e.g. there's no list of certificates)
 - **Silent update mode**, when the callback is queued immediately to the completion queue, but the `CertStore` performs the update on the background. The purpose of the silent update is to do not block your app's startup, but still keep that the list of fingerprints is up to date. The periodicity of the updates are determined automatically by the `CertStore`, but don't worry, we don't want to eat your users' data plan :)
 
-You can optionally provide the completion dispatch queue for scheduling the completion block. This may be useful for situations, when you're calling update from other than "main" thread (for example, from your own networking code). The default queue for the completion is `.main`.
+You can optionally provide the completion dispatch queue for scheduling the completion block. This may be useful for situations when you're calling update from other than "main" thread (for example, from your own networking code). The default queue for the completion is `.main`.
 
 ## Fingerprint validation
 
@@ -217,18 +217,18 @@ Each `validate` methods returns `CertStore.ValidationResult` enumeration with fo
 
   The untrusted result means that `CertStore` has some fingerprints stored in its
   database, but none matches the value you requested for validation. The right
-  response on this situation is to always cancel the ongoing TLS handshake (e.g. report
+  response on this situation is always to cancel the ongoing TLS handshake (e.g. report
   [.cancelAuthenticationChallenge](https://developer.apple.com/documentation/foundation/urlsession/authchallengedisposition)
   to the completion callback)
 
-- `empty` - the fingerprints database is empty, or there's no fingerprint for validated common name.
+- `empty` - the fingerprints database is empty, or there's no fingerprint for the validated common name.
 
   The "empty" validation result typically means that the `CertStore` should update
   the list of certificates immediately. Before you do this, you should check whether
   the requested common name is what's you're expecting. To simplify this step, you can set 
   the list of expected common names in the `CertStoreConfiguration` and treat all others as untrusted.
     
-  For all situations, the right response on this situation is to always cancel the ongoing
+  For all situations, the right response on this situation is always to cancel the ongoing
   TLS handshake (e.g. report [.cancelAuthenticationChallenge](https://developer.apple.com/documentation/foundation/urlsession/authchallengedisposition)
   to the completion callback)
 
@@ -261,7 +261,7 @@ class YourUrlSessionDelegate: NSObject, URLSessionDelegate {
 
 The `WultraSSLPinning/PowerAuthIntegration` cocoapod sub-spec provides a several additional classes which enhances the PowerAuth SDK functionality. The most important one is the `PowerAuthSslPinningValidationStrategy` class, which implements SSL pinning with using fingerprints, stored in the `CertStore`. You can simply instantiate this object from the existing `CertStore` and set it to the `PA2ClientConfiguration`. Then the class will provide SSL pinning for all communication initiated from the PowerAuth SDK.
 
-For example, this is how the configuration sequence may looks like if you want to use both, `PowerAuthSDK` and `CertStore`, as singletons:
+For example, this is how the configuration sequence may look like if you want to use both, `PowerAuthSDK` and `CertStore`, as singletons:
 
 ```swift
 import WultraSSLPinning
@@ -307,17 +307,17 @@ extension PowerAuthSDK {
 
 ### Why different domain for `serviceUrl`?
 
-iOS is using TLS cache for all secure connections to the remote servers. The cache keeps already established connection alive for a while, to speedup the next HTTPS request (see [Apple's Technical Q&A](https://developer.apple.com/library/archive/qa/qa1727/_index.html) for more information). Unfortunately, you don't have the direct control on that cache, so you cannot close already established connection. That unfortunately, opens a small door for the attacker. Imagine this scenario:
+iOS is using TLS cache for all secure connections to the remote servers. The cache keeps already established connection alive for a while, to speed up the next HTTPS request (see [Apple's Technical Q&A](https://developer.apple.com/library/archive/qa/qa1727/_index.html) for more information). Unfortunately, you don't have the direct control on that cache, so you cannot close already established connection. That unfortunately, opens a small door for the attacker. Imagine this scenario:
 
 1. The connection to get the remote list of fingerprints should not be protected with pinning. The list must be accessed for all costs, so protecting it with the pinning may cause the cert store to deadlock itself (or simply move it to the next level, where you need to update the fingerprint which must protect getting the list of new fingerprints)
 2. You usually need to update the list of fingerprints at the application's startup, before everything else. 
 3. Due to step 1., the attacker can trick your app to get the list of certificates with using his rogue CA. This will not allow him to insert a new entry to the list, but that's not the point.
 4. If your API is on the same domain, then your app's connection will reuse the already established connection (opened in step 2. or 3.), via the MitM. And that's it.
 
-Well, not everything's lost. If you're using `URLSession` (probably yes), then you can re-create a new `URLSession`, because it has its own TLS cache. But all this is not well documented, so that's why we recommend to put the list of fingerprints on the different domain, to avoid this kind of conflicts in the TLS cache at all.
+Well, not everything's lost. If you're using `URLSession` (probably yes), then you can re-create a new `URLSession`, because it has its own TLS cache. But all this is not well documented, so that's why we recommend putting the list of fingerprints on the different domain, to avoid this kind of conflicts in the TLS cache at all.
 
 
-### Can library provide more debug information?
+### Can the library provide more debug information?
 
 Yes, you can change how much information is printed to the debug console:
 ```swift
@@ -326,7 +326,7 @@ WultraDebug.verboseLevel = .all
 
 ### Why dependency on PowerAuth2?
 
-The library requires several cryptographic primitives, which are normally not available in iOS (like ECDSA). The `PowerAuth2` already provides this functions and most of our clients are already using PowerAuth2 framework in their applications. So, for our purposes it makes sense to glue both libraries together.
+The library requires several cryptographic primitives, which are typically not available in iOS (like ECDSA). The `PowerAuth2` already provides this functions, and most of our clients are already using PowerAuth2 framework in their applications. So, for our purposes, it makes sense to glue both libraries together.
 
 But not everything is lost. The core of the library is using `CryptoProvider` protocol and therefore is implementation independent. We'll provide the standalone version of the pinning library later. 
 
@@ -334,11 +334,11 @@ But not everything is lost. The core of the library is using `CryptoProvider` pr
 
 ## License
 
-All sources are licensed using Apache 2.0 license, you can use them with no restriction. If you are using this library, please let us know. We will be happy to share and promote your project.
+All sources are licensed using Apache 2.0 license. You can use them with no restriction. If you are using this library, please let us know. We will be happy to share and promote your project.
 
 ## Contact
 
-If you need any assistance, do not hesitate to drop us a line at hello@wultra.com or at our official [gitter.im/wultra](https://gitter.im/wultra) channel.
+If you need any assistance, do not hesitate to drop us a line at hello@wultra.com or our official [gitter.im/wultra](https://gitter.im/wultra) channel.
 
 ### Security Disclosure
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 The SSL pinning (or [public key, or certificate pinning](https://en.wikipedia.org/wiki/Transport_Layer_Security#Certificate_pinning)) is a technique mitigating [Man-in-the-middle attacks](https://en.wikipedia.org/wiki/Man-in-the-middle_attack) against the secure HTTP communication. The typical iOS solution is to bundle the hash of the certificate, or the exact data of the certificate to the application and validate the incoming challenge in the `URLSessionDelegate`. This in general works well, but it has, unfortunately, one major drawback of the certificate's expiration date. The certificate expiration forces you to update your application regularly before the certificate expires, but still, some percentage of the users don't update their apps automatically. So, the users on the older version, will not be able to contact the application servers.
 
-The solution to this problem is the dynamic SSL pinning, where the list of certificate fingerprints are securely downloaded from the remote server. The `WultraSSLPinning` library does precisely thist:
+The solution to this problem is the dynamic SSL pinning, where the list of certificate fingerprints are securely downloaded from the remote server. The `WultraSSLPinning` library does precisely this:
 
 - Manages the dynamic list of certificates, downloaded from the remote server
 - All entries in the list are signed with your private key and validated in the library with using the public key (we're using ECDSA-SHA-256 algorithm)


### PR DESCRIPTION
Quick semi-automated spell check...