### PR TITLE
Swift5 migration

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wultra/powerauth-mobile-sdk" "e22b78b3f269800f84cb5421042e50bc3eeab93e"
+github "wultra/powerauth-mobile-sdk" "e26bd9f2ef2c21e20f053fb1e6287aaf553b9d76"

--- a/Deploy/WultraSSLPinning.podspec
+++ b/Deploy/WultraSSLPinning.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.author = { 'Wultra s.r.o.' => 'support@wultra.com' }
   s.source = { :git => 'https://github.com/wultra/ssl-pinning-ios.git', :tag => s.version }
   # Deployment targets
-  s.swift_version = '4.1'
+  s.swift_version = '5.0'
   s.ios.deployment_target = '8.0'
   # Sources
   

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Before you start using the library, you should also check our other related proj
 ### Requirements
 
 - iOS 8.0+
-- Xcode 9.4+
-- Swift 4.1+
+- Xcode 10.2+
+- Swift 5.0+
 
 ### CocoaPods
 

--- a/Source/Lib/CertStore+Storage.swift
+++ b/Source/Lib/CertStore+Storage.swift
@@ -20,7 +20,7 @@ internal extension CertStore {
     
     /// Loads cached data from the underlying persistent storage.
     /// Returns nil if no such data is stored.
-    internal func loadCachedData() -> CachedData? {
+    func loadCachedData() -> CachedData? {
         guard let encodedData = secureDataStore.loadData(forKey: self.instanceIdentifier) else {
             return nil
         }
@@ -31,7 +31,7 @@ internal extension CertStore {
     }
     
     /// Saves cached data to the underlying persistent storage.
-    internal func saveDataToCache(data: CachedData) {
+    func saveDataToCache(data: CachedData) {
         guard let encodedData = try? jsonEncoder().encode(data) else {
             return
         }
@@ -39,7 +39,7 @@ internal extension CertStore {
     }
     
     /// Loads fallback certificate from configuration provided in CertStore initialization.
-    internal func loadFallbackCertificate() -> CertificateInfo? {
+    func loadFallbackCertificate() -> CertificateInfo? {
         guard let fallbackData = configuration.fallbackCertificateData else {
             return nil
         }
@@ -50,7 +50,7 @@ internal extension CertStore {
     }
     
     /// Returns new instance of `JSONDecoder`, preconfigured for our data types deserialization.
-    internal func jsonDecoder() -> JSONDecoder {
+    func jsonDecoder() -> JSONDecoder {
         let decoder = JSONDecoder()
         decoder.dataDecodingStrategy = .base64
         decoder.dateDecodingStrategy = .secondsSince1970
@@ -58,7 +58,7 @@ internal extension CertStore {
     }
     
     /// Returns new instance of `JSONEncoder`, preconfigured for our data types serialization.
-    internal func jsonEncoder() -> JSONEncoder {
+    func jsonEncoder() -> JSONEncoder {
         let encoder = JSONEncoder()
         encoder.dataEncodingStrategy = .base64
         encoder.dateEncodingStrategy = .secondsSince1970

--- a/Source/Lib/CertStore+Update.swift
+++ b/Source/Lib/CertStore+Update.swift
@@ -19,7 +19,7 @@ import Foundation
 public extension CertStore {
     
     /// Defines modes of update request
-    public enum UpdateMode {
+    enum UpdateMode {
         
         /// The default mode keeps periodicity of handling on the CertStore
         case `default`
@@ -34,7 +34,7 @@ public extension CertStore {
     }
     
     /// Result from update certificates request.
-    public enum UpdateResult {
+    enum UpdateResult {
         
         /// Update succeeded
         case ok
@@ -77,7 +77,7 @@ public extension CertStore {
     /// - Parameter completion: The completion closure called at the end of operation, with following parameters:
     /// - Parameter result: Resut of the update operation
     /// - Parameter error: An optional error, returned in case that operation failed on communication with the remote location.
-    public func update(mode: UpdateMode = .default, completionQueue: DispatchQueue = .main, completion: @escaping (_ result: UpdateResult, _ error: Error?)->Void) -> Void {
+    func update(mode: UpdateMode = .default, completionQueue: DispatchQueue = .main, completion: @escaping (_ result: UpdateResult, _ error: Error?)->Void) -> Void {
         
         // Capture the current date.
         //
@@ -165,7 +165,7 @@ public extension CertStore {
                     // Received entry is already expired, just skip it.
                     continue
                 }
-                if newCertificates.index(of: newCI) != nil {
+                if newCertificates.firstIndex(of: newCI) != nil {
                     // This particular entry is already in the database, just skip it.
                     // Due to fact, that we're using the same array for newly accepted certs,
                     // then it will also filter duplicities received from the server.

--- a/Source/Lib/CertStore+Validation.swift
+++ b/Source/Lib/CertStore+Validation.swift
@@ -19,7 +19,7 @@ import Foundation
 public extension CertStore {
     
     /// The result of fingerprint validation
-    public enum ValidationResult {
+    enum ValidationResult {
         
         /// The challenged server certificate is trusted.
         ///
@@ -64,7 +64,7 @@ public extension CertStore {
     /// - Parameter fingerprint: A SHA-256 fingerprint calculated from certificate's data
     ///
     /// - Returns: validation result
-    public func validate(commonName: String, fingerprint: Data) -> ValidationResult {
+    func validate(commonName: String, fingerprint: Data) -> ValidationResult {
         
         // Check expected common names
         if let expected = configuration.expectedCommonNames {
@@ -115,7 +115,7 @@ public extension CertStore {
     /// - Parameter certificateData: Server certificate in DER format
     ///
     /// - Returns: validation result
-    public func validate(commonName: String, certificateData: Data) -> ValidationResult {
+    func validate(commonName: String, certificateData: Data) -> ValidationResult {
         let fingerprint = cryptoProvider.hashSha256(data: certificateData)
         return validate(commonName: commonName, fingerprint: fingerprint)
     }
@@ -125,7 +125,7 @@ public extension CertStore {
     /// - Parameter challenge: An authentication challenge to be validated
     ///
     /// - Returns: validation result
-    public func validate(challenge: URLAuthenticationChallenge) -> ValidationResult {
+    func validate(challenge: URLAuthenticationChallenge) -> ValidationResult {
         // Acquire various nullable objects at first
         guard let serverTrust = challenge.protectionSpace.serverTrust,
             let serverCert = SecTrustGetCertificateAtIndex(serverTrust, 0),

--- a/Source/Lib/CertStore.swift
+++ b/Source/Lib/CertStore.swift
@@ -96,7 +96,7 @@ internal extension CertStore {
     /// Internal function returns array of `CertificateInfo` objects. The array
     /// contains the fallback certificate, if provided, at the last position.
     /// The operation is thread safe.
-    internal func getCertificates() -> [CertificateInfo] {
+    func getCertificates() -> [CertificateInfo] {
         // Acquire semaphore
         semaphore.wait()
         defer { semaphore.signal() }
@@ -112,7 +112,7 @@ internal extension CertStore {
     }
     
     /// Internal function returns whole `CachedData` structure. The operation is thread safe.
-    internal func getCachedData() -> CachedData? {
+    func getCachedData() -> CachedData? {
         // Acquire semaphore
         semaphore.wait()
         defer { semaphore.signal() }
@@ -125,7 +125,7 @@ internal extension CertStore {
     
     /// Internal function allows atomic update of `CachedData` structure. The provided
     /// update closure is called when exclusive access to data is guaranteed.
-    internal func updateCachedData(updateClosure: (CachedData?)->CachedData?) -> Void {
+    func updateCachedData(updateClosure: (CachedData?)->CachedData?) -> Void {
         // Acquire semaphore
         semaphore.wait()
         defer { semaphore.signal() }

--- a/Source/Lib/Service/WultraDebug.swift
+++ b/Source/Lib/Service/WultraDebug.swift
@@ -70,6 +70,6 @@ public class WultraDebug {
     
     /// Throws a fatal error without revealing developer's build path in "file:" parameter.
     public static func fatalError(_ message: @autoclosure ()->String) -> Never {
-        Swift.fatalError(message, file: "", line: 1)
+        Swift.fatalError(message(), file: "", line: 1)
     }
 }

--- a/Source/Plugins/PowerAuth/PowerAuthIntegration.swift
+++ b/Source/Plugins/PowerAuth/PowerAuthIntegration.swift
@@ -22,7 +22,7 @@ public extension CertStore {
     /// The constructed validation strategy object will use this instance of `CertStore` for server certificate
     /// validation. Note that the function always constructs new object, so it's effective to create just one instance
     /// of the validator per `CertStore`.
-    public func powerAuthSslValidationStrategy() -> PA2ClientSslValidationStrategy {
+    func powerAuthSslValidationStrategy() -> PA2ClientSslValidationStrategy {
         return PowerAuthSslPinningValidationStrategy(certStore: self)
     }
     
@@ -42,7 +42,7 @@ public extension CertStore {
     ///     }
     /// }
     /// ```
-    public static func powerAuthCertStore(configuration: CertStoreConfiguration) -> CertStore {
+    static func powerAuthCertStore(configuration: CertStoreConfiguration) -> CertStore {
         return CertStore(
             configuration: configuration,
             cryptoProvider: PowerAuthCryptoProvider(),

--- a/WultraSSLPinning.podspec
+++ b/WultraSSLPinning.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.author = { 'Wultra s.r.o.' => 'support@wultra.com' }
   s.source = { :git => 'https://github.com/wultra/ssl-pinning-ios.git', :tag => s.version }
   # Deployment targets
-  s.swift_version = '4.1'
+  s.swift_version = '5.0'
   s.ios.deployment_target = '8.0'
   # Sources
   

--- a/WultraSSLPinning.xcodeproj/project.pbxproj
+++ b/WultraSSLPinning.xcodeproj/project.pbxproj
@@ -371,11 +371,11 @@
 				TargetAttributes = {
 					BF8BB77A214021EF0097315B = {
 						CreatedOnToolsVersion = 9.4.1;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1030;
 					};
 					BFCB8150213D917600615ADA = {
 						CreatedOnToolsVersion = 9.4.1;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1030;
 					};
 				};
 			};
@@ -493,7 +493,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = io.getlime.lib.WultraSSLPinningTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -514,7 +514,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = io.getlime.lib.WultraSSLPinningTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -668,7 +668,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -697,7 +697,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.getlime.lib.WultraSSLPinning;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
- Migrated to Swift5 API
- Getting rid of compilation warnings
- updated resolved Cartfile to newest powerauth SDK
- updated documentation that the library requires  Xcode 10.2 and Swift 5.0+