### PR TITLE
Issues/11 ssl validation strategy

### DIFF
--- a/Source/Lib/CertStore+Update.swift
+++ b/Source/Lib/CertStore+Update.swift
@@ -161,7 +161,7 @@ public extension CertStore {
             guard let challenge = challenge else {
                 WultraDebug.fatalError("Challenge must be set")
             }
-            guard let signature = responseHeaders["X-Cert-Pinning-Signature"] else {
+            guard let signature = responseHeaders["x-cert-pinning-signature"] else {
                 WultraDebug.error("CertStore: Missing signature header.")
                 return .invalidSignature
             }

--- a/Source/Lib/CertStore.swift
+++ b/Source/Lib/CertStore.swift
@@ -35,7 +35,7 @@ public class CertStore {
         self.configuration = configuration
         self.cryptoProvider = cryptoProvider
         self.secureDataStore = secureDataStore
-        self.remoteDataProvider = RestAPI(baseURL: configuration.serviceUrl)
+        self.remoteDataProvider = RestAPI(baseURL: configuration.serviceUrl, sslValidationStrategy: configuration.sslValidationStrategy)
     }
     
     /// Internal constructor, suitable for unit tests.

--- a/Source/Lib/CertStoreConfiguration.swift
+++ b/Source/Lib/CertStoreConfiguration.swift
@@ -82,6 +82,13 @@ public struct CertStoreConfiguration {
     /// The default value is 2 weeks.
     public let expirationUpdateTreshold: TimeInterval
     
+    /// Defines the validation strategy for HTTPS connections initiated from the library itself. The default
+    /// validation strategy implements a default URLSession handling.
+    ///
+    /// Be aware that altering this option may put your application at risk. You should not ship your application
+    /// to production with SSL validation turned off.
+    public let sslValidationStrategy: SSLValidationStrategy
+    
     /// Default constructor.
     public init(
         serviceUrl: URL,
@@ -91,7 +98,8 @@ public struct CertStoreConfiguration {
         identifier: String? = nil,
         fallbackCertificatesData: Data? = nil,
         periodicUpdateInterval: TimeInterval = 7*24*60*60,
-        expirationUpdateTreshold: TimeInterval = 14*24*60*60)
+        expirationUpdateTreshold: TimeInterval = 14*24*60*60,
+        sslValidationStrategy: SSLValidationStrategy = .default)
     {
         self.serviceUrl = serviceUrl
         self.publicKey = publicKey
@@ -101,6 +109,7 @@ public struct CertStoreConfiguration {
         self.fallbackCertificatesData = fallbackCertificatesData
         self.periodicUpdateInterval = periodicUpdateInterval
         self.expirationUpdateTreshold = expirationUpdateTreshold
+        self.sslValidationStrategy = sslValidationStrategy
     }
 }
 
@@ -117,6 +126,9 @@ extension CertStoreConfiguration {
         // Check "http"
         if serviceUrl.absoluteString.hasPrefix("http:") {
             WultraDebug.warning("CertStore: '.serviceUrl' should point to 'https' server.")
+        }
+        if sslValidationStrategy == .noValidation {
+            WultraDebug.warning("CertStore: '.sslValidationStrategy.noValidation' should not be used in production.")
         }
         // Validate fallback certificate data
         if let fallbackData = fallbackCertificatesData {

--- a/Source/Lib/Protocols/SSLValidationStrategy.swift
+++ b/Source/Lib/Protocols/SSLValidationStrategy.swift
@@ -1,0 +1,41 @@
+//
+// Copyright 2020 Wultra s.r.o.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+
+import Foundation
+
+/// Validation strategy decides how HTTPS requests initiated from the library should be handled.
+public enum SSLValidationStrategy {
+    
+    /// Will use default URLSession handling
+    case `default`
+    
+    /// Will trust https connections with invalid certificates
+    case noValidation
+ 
+    /// Internal function implements SSL chain validation depending on validation strategy.
+    internal func validate(challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        switch self {
+        case .noValidation:
+            if let st = challenge.protectionSpace.serverTrust {
+                completionHandler(.useCredential, URLCredential(trust: st))
+            } else {
+                completionHandler(.performDefaultHandling, nil)
+            }
+        case .default:
+            completionHandler(.performDefaultHandling, nil)
+        }
+    }
+}

--- a/Source/Lib/Service/RemoteDataProvider.swift
+++ b/Source/Lib/Service/RemoteDataProvider.swift
@@ -28,7 +28,7 @@ internal struct RemoteDataRequest {
 internal struct RemoteDataResponse {
     /// Result with received `Data`.
     let result: Result<Data, Error>
-    /// Headers received in the response.
+    /// Headers received in the response. Note that all header names are lowercased.
     let responseHeaders: [String:String]
 }
 

--- a/Source/Lib/Service/RestAPI.swift
+++ b/Source/Lib/Service/RestAPI.swift
@@ -95,7 +95,7 @@ fileprivate extension HTTPURLResponse {
                 guard let key = tuple.key as? String, let value = tuple.value as? String else {
                     return
                 }
-                result[key] = value
+                result[key.lowercased()] = value
             }
     }
 }

--- a/Tests/CertStoreTests_NetworkChallenge.swift
+++ b/Tests/CertStoreTests_NetworkChallenge.swift
@@ -54,7 +54,7 @@ class CertStoreTests_NetworkChallenge: XCTestCase {
         )
         cryptoProvider = PowerAuthCryptoProvider()
         dataStore = TestingSecureDataStore()
-        remoteDataProvider = RestAPI(baseURL: config.serviceUrl)
+        remoteDataProvider = RestAPI(baseURL: config.serviceUrl, sslValidationStrategy: .default)
         certStore = CertStore(
             configuration: config,
             cryptoProvider: cryptoProvider,

--- a/Tests/CertStoreTests_NetworkStatic.swift
+++ b/Tests/CertStoreTests_NetworkStatic.swift
@@ -57,7 +57,7 @@ class CertStoreTests_NetworkStatic: XCTestCase {
         )
         cryptoProvider = PowerAuthCryptoProvider()
         dataStore = TestingSecureDataStore()
-        remoteDataProvider = RestAPI(baseURL: config.serviceUrl)
+        remoteDataProvider = RestAPI(baseURL: config.serviceUrl, sslValidationStrategy: .default)
         certStore = CertStore(
             configuration: config,
             cryptoProvider: cryptoProvider,

--- a/Tests/Providers/TestingRemoteDataProvider.swift
+++ b/Tests/Providers/TestingRemoteDataProvider.swift
@@ -81,7 +81,7 @@ class TestingRemoteDataProvider: RemoteDataProvider {
             dataToSign.append("&".data(using: .ascii)!)
             dataToSign.append(data)
             let signature = ECDSA.sign(privateKey: privateKey, data: dataToSign).base64EncodedString()
-            return (data, ["X-Cert-Pinning-Signature" : signature])
+            return (data, ["x-cert-pinning-signature" : signature])
         }
         return self
     }

--- a/WultraSSLPinning.xcodeproj/project.pbxproj
+++ b/WultraSSLPinning.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		BF8BB776213FDA420097315B /* CachedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8BB775213FDA420097315B /* CachedData.swift */; };
 		BF8BB77E214021EF0097315B /* CertStoreTests_Update.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8BB77D214021EF0097315B /* CertStoreTests_Update.swift */; };
 		BF8BB780214021EF0097315B /* WultraSSLPinning.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BFCB8151213D917600615ADA /* WultraSSLPinning.framework */; };
+		BF8EAAF8256C0EBA00239319 /* SSLValidationStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8EAAF7256C0EBA00239319 /* SSLValidationStrategy.swift */; };
 		BFABCD5321482CF000A9221F /* CertStoreTests_NetworkStatic.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFABCD5121482CAF00A9221F /* CertStoreTests_NetworkStatic.swift */; };
 		BFABCD56214831D500A9221F /* TestingSessionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFABCD5421482F6D00A9221F /* TestingSessionDelegate.swift */; };
 		BFABCD5A2149804A00A9221F /* UpdateScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFABCD592149804A00A9221F /* UpdateScheduler.swift */; };
@@ -103,6 +104,7 @@
 		BF8BB77B214021EF0097315B /* WultraSSLPinningTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WultraSSLPinningTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BF8BB77D214021EF0097315B /* CertStoreTests_Update.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertStoreTests_Update.swift; sourceTree = "<group>"; };
 		BF8BB77F214021EF0097315B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		BF8EAAF7256C0EBA00239319 /* SSLValidationStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSLValidationStrategy.swift; sourceTree = "<group>"; };
 		BFABCD5121482CAF00A9221F /* CertStoreTests_NetworkStatic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertStoreTests_NetworkStatic.swift; sourceTree = "<group>"; };
 		BFABCD5421482F6D00A9221F /* TestingSessionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestingSessionDelegate.swift; sourceTree = "<group>"; };
 		BFABCD592149804A00A9221F /* UpdateScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateScheduler.swift; sourceTree = "<group>"; };
@@ -294,6 +296,7 @@
 			children = (
 				BFCB8176213D9F8400615ADA /* CryptoProvider.swift */,
 				BFCB8178213D9FEB00615ADA /* SecureDataStore.swift */,
+				BF8EAAF7256C0EBA00239319 /* SSLValidationStrategy.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -378,7 +381,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0940;
-				LastUpgradeCheck = 1200;
+				LastUpgradeCheck = 1220;
 				ORGANIZATIONNAME = "Lime - HighTech Solutions";
 				TargetAttributes = {
 					BF8BB77A214021EF0097315B = {
@@ -468,6 +471,7 @@
 				BF8BB774213F05B40097315B /* RestAPI.swift in Sources */,
 				BFCB8193213EB59700615ADA /* CertificateInfo.swift in Sources */,
 				BFCB817E213DA71100615ADA /* PowerAuthSecureDataStore.swift in Sources */,
+				BF8EAAF8256C0EBA00239319 /* SSLValidationStrategy.swift in Sources */,
 				BFCB818A213EAD1300615ADA /* CertStoreConfiguration.swift in Sources */,
 				BFCB8188213EAC1300615ADA /* CertStore.swift in Sources */,
 				BF026B022141CC9700A47E90 /* WultraDebug.swift in Sources */,

--- a/WultraSSLPinning.xcodeproj/xcshareddata/xcschemes/WultraSSLPinning.xcscheme
+++ b/WultraSSLPinning.xcodeproj/xcshareddata/xcschemes/WultraSSLPinning.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1220"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
This change adds SSL validation strategy to certstore configuration and also fixes incompatibility with server returning lowercased response headers.

Close #11
Close #12 